### PR TITLE
Updtes README & metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,5 @@
 {
     "license": "CC-BY-NC-SA-4.0",
-    "description": "<p>This corpus of annotated <a href=\"https://musescore.org\">MuseScore</a> files has been created within the <a href=\"https://github.com/DCMLab/dcml_corpora\">DCML corpus initiative</a> and employs the <a href=\"https://github.com/DCMLab/standards\">DCML harmony annotation standard</a>. It is one out of nine similar corpora that have been grouped together to <a href=\"https://doi.org/10.5281/zenodo.7473560\">An Annotated Corpus of Tonal Piano Music from the Long 19th Century</a> which comes with a data report that is currently under review.</p>\n\n<p>The dataset lives on GitHub (link under &quot;Related identifiers&quot;) and is stored on Zenodo purely for conservation and automatic DOI generation for new GitHub releases. For technical reasons, we include only brief, generic instructions on how to use the data. For more detailed documentation, please refer to the dataset&#39;s GitHub page.</p>\n\n<p><strong>What is included</strong></p>\n\n<p>The dataset includes annotated MusicScores <strong>.mscx</strong> files that have been created with <a href=\"https://github.com/musescore/MuseScore/releases/tag/v3.6.2\">MuseScore 3.6.2</a> and can be opened with any MuseScore 3, or later version. Apart from that, the score information (measures, notes, harmony labels) have been extracted in the form of TSV files which can be found respectively in the folders <code>measures</code>, <code>notes</code>, and <code>harmonies</code>. They have been extracted with the Python library <a href=\"https://pypi.org/project/ms3/\">ms3</a> and its documentation has a <a href=\"https://ms3.readthedocs.io/columns\">column glossary for looking up the meaning of a column</a>.</p>\n\n<p><strong>Getting the data</strong></p>\n\n<p>You can download the dataset as a ZIP file from Zenodo or GitHub. Please note that these automatically generated ZIP files do not include submodules, which would appear as empty folders. If you need ZIP files, you will need to find the submodule repositories (e.g. via GitHub) and download them individually.</p>\n\n<p>Apart from that, there is the possibility to git-clone the GitHub repository to your disk. This has the advantage that it allows to version-control any changes you want to make to the dataset and to ask for your changes to be included (&quot;merged&quot;) in a future version.</p>",
     "contributors": [
         {
             "type": "DataCollector",
@@ -27,7 +26,7 @@
             "name": "Hanné Becker"
         }
     ],
-    "title": "Johann Christian Bach – Keyboard Sonatas",
+    "title": "Johann Christian Bach – Keyboard Sonatas (A corpus of annotated scores)",
     "keywords": [
         "music research",
         "music theory",
@@ -93,6 +92,12 @@
             "scheme": "url",
             "identifier": "https://dcmlab.github.io/jc_bach_sonatas/",
             "relation": "isDocumentedBy"
+        },
+        {
+            "scheme": "doi",
+            "identifier": "10.5281/zenodo.13844105",
+            "relation": "isPartOf",
+            "resource_type":"dataset"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -17,19 +17,23 @@ This corpus of annotated [MuseScore](https://musescore.org) files has been creat
 the [DCML corpus initiative](https://github.com/DCMLab/dcml_corpora) and employs
 the [DCML harmony annotation standard](https://github.com/DCMLab/standards).
 
-Johann Christian, the "London Bach," pioneered an impressive number of compositional innovations\r
-that were soon to become ubiquitous in the Classical style. In particular, he laid significant\r
-groundwork for the development of the symphony, contributing harmonic expectations to the\r
-new sonata-allegro form and experimenting with independent melodies in wind instruments. Though\r
-he wrote relatively little for solo keyboard, the sonatas in this repository are no less\r 
-pivotal. Working with an early form of the pianoforte called a "Hammerflügel," Bach leveraged\r
-the harmonic flexibility of this instrument, as well as its ability to produce subtly detailed\r
-and balanced textures, to produce an outstanding technical exemplar for sonata composition.\r
-It is very easy to perceive in this music the influence Bach had on his student Wolfgang Amadeus\r
-Mozart, and indeed, three of Mozart's early concertos (those of K.107) are in fact orchestrations\r
+Johann Christian, the "London Bach," pioneered an impressive number of compositional innovations
+that were soon to become ubiquitous in the Classical style. In particular, he laid significant
+groundwork for the development of the symphony, contributing harmonic expectations to the
+new sonata-allegro form and experimenting with independent melodies in wind instruments. Though
+he wrote relatively little for solo keyboard, the sonatas in this repository are no less
+pivotal. Working with an early form of the pianoforte called a "Hammerflügel," Bach leveraged
+the harmonic flexibility of this instrument, as well as its ability to produce subtly detailed
+and balanced textures, to produce an outstanding technical exemplar for sonata composition.
+It is very easy to perceive in this music the influence Bach had on his student Wolfgang Amadeus
+Mozart, and indeed, three of Mozart's early concertos (those of K.107) are in fact orchestrations
 of sonatas found in this repository, Bach's op. 5 nos. 2-4.
 
-The two volumes collected in this repository are op. 5 and op. 17. The former was composed around\r the time of Bach's arrival in London, prior to his appointment as music master to Queen Charlotte,\r while the latter appeared shortly before Bach died indebted at 46. Both volumes demonstrate a\r clever combination of instrumental flash and tuneful clarity whose influence upon the Classical\r style is palpable. Our annotations of these works are ideal for quantifying exactly what those\r
+The two volumes collected in this repository are op. 5 and op. 17. The former was composed around the time of Bach's
+arrival in London, prior to his appointment as music master to Queen Charlotte, while the latter appeared shortly before
+Bach died indebted at 46. Both volumes demonstrate a clever combination of instrumental flash and tuneful clarity whose
+influence upon the Classical style is palpable. Our annotations of these works are ideal for quantifying exactly what
+those
 Classical expectations are in their purest form.
 
 ## Cite as

--- a/README.md
+++ b/README.md
@@ -13,7 +13,24 @@ and serves as welcome page for both
 For information on how to obtain and use the dataset, please refer to [this documentation page](https://dcmlab.github.io/jc_bach_sonatas/introduction).
 
 # Johann Christian Bach – Keyboard Sonatas
+This corpus of annotated [MuseScore](https://musescore.org) files has been created within
+the [DCML corpus initiative](https://github.com/DCMLab/dcml_corpora) and employs
+the [DCML harmony annotation standard](https://github.com/DCMLab/standards).
 
+Johann Christian, the "London Bach," pioneered an impressive number of compositional innovations\r
+that were soon to become ubiquitous in the Classical style. In particular, he laid significant\r
+groundwork for the development of the symphony, contributing harmonic expectations to the\r
+new sonata-allegro form and experimenting with independent melodies in wind instruments. Though\r
+he wrote relatively little for solo keyboard, the sonatas in this repository are no less\r 
+pivotal. Working with an early form of the pianoforte called a "Hammerflügel," Bach leveraged\r
+the harmonic flexibility of this instrument, as well as its ability to produce subtly detailed\r
+and balanced textures, to produce an outstanding technical exemplar for sonata composition.\r
+It is very easy to perceive in this music the influence Bach had on his student Wolfgang Amadeus\r
+Mozart, and indeed, three of Mozart's early concertos (those of K.107) are in fact orchestrations\r
+of sonatas found in this repository, Bach's op. 5 nos. 2-4.
+
+The two volumes collected in this repository are op. 5 and op. 17. The former was composed around\r the time of Bach's arrival in London, prior to his appointment as music master to Queen Charlotte,\r while the latter appeared shortly before Bach died indebted at 46. Both volumes demonstrate a\r clever combination of instrumental flash and tuneful clarity whose influence upon the Classical\r style is palpable. Our annotations of these works are ideal for quantifying exactly what those\r
+Classical expectations are in their purest form.
 
 ## Cite as
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Version](https://img.shields.io/github/v/release/DCMLab/jc_bach_sonatas?display_name=tag)
-[![DOI](https://zenodo.org/badge/{{ zenodo_badge_id }}.svg)](https://zenodo.org/badge/latestdoi/{{ zenodo_badge_id }})
+[![DOI](https://zenodo.org/badge/{{ zenodo_badge_id }}.svg)](https://doi.org/{{ concept_doi }})
 ![GitHub repo size](https://img.shields.io/github/repo-size/DCMLab/jc_bach_sonatas)
 ![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-9cf)
 
@@ -12,7 +12,8 @@ and serves as welcome page for both
 
 For information on how to obtain and use the dataset, please refer to [this documentation page](https://dcmlab.github.io/jc_bach_sonatas/introduction).
 
-# Johann Christian Bach – Keyboard Sonatas
+# Johann Christian Bach – Keyboard Sonatas (A corpus of annotated scores)
+
 This corpus of annotated [MuseScore](https://musescore.org) files has been created within
 the [DCML corpus initiative](https://github.com/DCMLab/dcml_corpora) and employs
 the [DCML harmony annotation standard](https://github.com/DCMLab/standards).
@@ -36,7 +37,60 @@ influence upon the Classical style is palpable. Our annotations of these works a
 those
 Classical expectations are in their purest form.
 
-## Cite as
+## Getting the data
+
+* download repository as a [ZIP file](https://github.com/DCMLab/jc_bach_sonatas/archive/main.zip)
+* download a [Frictionless Datapackage](https://specs.frictionlessdata.io/data-package/) that includes concatenations
+  of the TSV files in the four folders (`measures`, `notes`, `chords`, and `harmonies`) and a JSON descriptor:
+  * [jc_bach_sonatas.zip](https://github.com/DCMLab/jc_bach_sonatas/releases/latest/download/jc_bach_sonatas.zip)
+  * [jc_bach_sonatas.datapackage.json](https://github.com/DCMLab/jc_bach_sonatas/releases/latest/download/jc_bach_sonatas.datapackage.json)
+* clone the repo: `git clone https://github.com/DCMLab/jc_bach_sonatas.git` 
+
+
+## Data Formats
+
+Each piece in this corpus is represented by five files with identical name prefixes, each in its own folder. 
+For example, the first movement of the first sonata op. 5 no. 1 has the following files:
+
+* `MS3/wa01op05no1a_Allegretto.mscx`: Uncompressed MuseScore 3.6.2 file including the music and annotation labels.
+* `notes/wa01op05no1a_Allegretto.notes.tsv`: A table of all note heads contained in the score and their relevant features (not each of them represents an onset, some are tied together)
+* `measures/wa01op05no1a_Allegretto.measures.tsv`: A table with relevant information about the measures in the score.
+* `chords/wa01op05no1a_Allegretto.chords.tsv`: A table containing layer-wise unique onset positions with the musical markup (such as dynamics, articulation, lyrics, figured bass, etc.).
+* `harmonies/wa01op05no1a_Allegretto.harmonies.tsv`: A table of the included harmony labels (including cadences and phrases) with their positions in the score.
+
+Each TSV file comes with its own JSON descriptor that describes the meanings and datatypes of the columns ("fields") it contains,
+follows the [Frictionless specification](https://specs.frictionlessdata.io/tabular-data-resource/),
+and can be used to validate and correctly load the described file. 
+
+### Opening Scores
+
+After navigating to your local copy, you can open the scores in the folder `MS3` with the free and open source score
+editor [MuseScore](https://musescore.org). Please note that the scores have been edited, annotated and tested with
+[MuseScore 3.6.2](https://github.com/musescore/MuseScore/releases/tag/v3.6.2). 
+MuseScore 4 has since been released which renders them correctly but cannot store them back in the same format.
+
+### Opening TSV files in a spreadsheet
+
+Tab-separated value (TSV) files are like Comma-separated value (CSV) files and can be opened with most modern text
+editors. However, for correctly displaying the columns, you might want to use a spreadsheet or an addon for your
+favourite text editor. When you use a spreadsheet such as Excel, it might annoy you by interpreting fractions as
+dates. This can be circumvented by using `Data --> From Text/CSV` or the free alternative
+[LibreOffice Calc](https://www.libreoffice.org/download/download/). Other than that, TSV data can be loaded with
+every modern programming language.
+
+### Loading TSV files in Python
+
+Since the TSV files contain null values, lists, fractions, and numbers that are to be treated as strings, you may want
+to use this code to load any TSV files related to this repository (provided you're doing it in Python). After a quick
+`pip install -U ms3` (requires Python 3.10 or later) you'll be able to load any TSV like this:
+
+```python
+import ms3
+
+labels = ms3.load_tsv("harmonies/wa01op05no1a_Allegretto.harmonies.tsv")
+notes = ms3.load_tsv("notes/wa01op05no1a_Allegretto.notes.tsv")
+```
+
 
 ## Version history
 
@@ -45,6 +99,10 @@ See the [GitHub releases](https://github.com/DCMLab/jc_bach_sonatas/releases).
 ## Questions, Suggestions, Corrections, Bug Reports
 
 Please [create an issue](https://github.com/DCMLab/jc_bach_sonatas/issues) and/or feel free to fork and submit pull requests.
+
+## Cite as
+
+> Johannes Hentschel, Yannis Rammos, Markus Neuwirth, & Martin Rohrmeier. (2025). Johann Christian Bach – Keyboard Sonatas [Data set]. Zenodo. https://doi.org/{{ concept_doi }}
 
 ## License
 


### PR DESCRIPTION
This is a README file for a data repository originating from the [DCML corpus initiative](https://github.com/DCMLab/dcml_corpora)
and serves as welcome page for both 

* the GitHub repo [https://github.com/DCMLab/jc_bach_sonatas](https://github.com/DCMLab/jc_bach_sonatas) and the corresponding
* documentation page [https://dcmlab.github.io/jc_bach_sonatas](https://dcmlab.github.io/jc_bach_sonatas)

For information on how to obtain and use the dataset, please refer to [this documentation page](https://dcmlab.github.io/jc_bach_sonatas/introduction).

# Johann Christian Bach – Keyboard Sonatas (A corpus of annotated scores)

This corpus of annotated [MuseScore](https://musescore.org) files has been created within
the [DCML corpus initiative](https://github.com/DCMLab/dcml_corpora) and employs
the [DCML harmony annotation standard](https://github.com/DCMLab/standards).

Johann Christian, the "London Bach," pioneered an impressive number of compositional innovations
that were soon to become ubiquitous in the Classical style. In particular, he laid significant
groundwork for the development of the symphony, contributing harmonic expectations to the
new sonata-allegro form and experimenting with independent melodies in wind instruments. Though
he wrote relatively little for solo keyboard, the sonatas in this repository are no less
pivotal. Working with an early form of the pianoforte called a "Hammerflügel," Bach leveraged
the harmonic flexibility of this instrument, as well as its ability to produce subtly detailed
and balanced textures, to produce an outstanding technical exemplar for sonata composition.
It is very easy to perceive in this music the influence Bach had on his student Wolfgang Amadeus
Mozart, and indeed, three of Mozart's early concertos (those of K.107) are in fact orchestrations
of sonatas found in this repository, Bach's op. 5 nos. 2-4.

The two volumes collected in this repository are op. 5 and op. 17. The former was composed around the time of Bach's
arrival in London, prior to his appointment as music master to Queen Charlotte, while the latter appeared shortly before
Bach died indebted at 46. Both volumes demonstrate a clever combination of instrumental flash and tuneful clarity whose
influence upon the Classical style is palpable. Our annotations of these works are ideal for quantifying exactly what
those
Classical expectations are in their purest form.

## Getting the data

* download repository as a [ZIP file](https://github.com/DCMLab/jc_bach_sonatas/archive/main.zip)
* download a [Frictionless Datapackage](https://specs.frictionlessdata.io/data-package/) that includes concatenations
  of the TSV files in the four folders (`measures`, `notes`, `chords`, and `harmonies`) and a JSON descriptor:
  * [jc_bach_sonatas.zip](https://github.com/DCMLab/jc_bach_sonatas/releases/latest/download/jc_bach_sonatas.zip)
  * [jc_bach_sonatas.datapackage.json](https://github.com/DCMLab/jc_bach_sonatas/releases/latest/download/jc_bach_sonatas.datapackage.json)
* clone the repo: `git clone https://github.com/DCMLab/jc_bach_sonatas.git` 


## Data Formats

Each piece in this corpus is represented by five files with identical name prefixes, each in its own folder. 
For example, the first movement of the first sonata op. 5 no. 1 has the following files:

* `MS3/wa01op05no1a_Allegretto.mscx`: Uncompressed MuseScore 3.6.2 file including the music and annotation labels.
* `notes/wa01op05no1a_Allegretto.notes.tsv`: A table of all note heads contained in the score and their relevant features (not each of them represents an onset, some are tied together)
* `measures/wa01op05no1a_Allegretto.measures.tsv`: A table with relevant information about the measures in the score.
* `chords/wa01op05no1a_Allegretto.chords.tsv`: A table containing layer-wise unique onset positions with the musical markup (such as dynamics, articulation, lyrics, figured bass, etc.).
* `harmonies/wa01op05no1a_Allegretto.harmonies.tsv`: A table of the included harmony labels (including cadences and phrases) with their positions in the score.

Each TSV file comes with its own JSON descriptor that describes the meanings and datatypes of the columns ("fields") it contains,
follows the [Frictionless specification](https://specs.frictionlessdata.io/tabular-data-resource/),
and can be used to validate and correctly load the described file. 

### Opening Scores

After navigating to your local copy, you can open the scores in the folder `MS3` with the free and open source score
editor [MuseScore](https://musescore.org). Please note that the scores have been edited, annotated and tested with
[MuseScore 3.6.2](https://github.com/musescore/MuseScore/releases/tag/v3.6.2). 
MuseScore 4 has since been released which renders them correctly but cannot store them back in the same format.

### Opening TSV files in a spreadsheet

Tab-separated value (TSV) files are like Comma-separated value (CSV) files and can be opened with most modern text
editors. However, for correctly displaying the columns, you might want to use a spreadsheet or an addon for your
favourite text editor. When you use a spreadsheet such as Excel, it might annoy you by interpreting fractions as
dates. This can be circumvented by using `Data --> From Text/CSV` or the free alternative
[LibreOffice Calc](https://www.libreoffice.org/download/download/). Other than that, TSV data can be loaded with
every modern programming language.

### Loading TSV files in Python

Since the TSV files contain null values, lists, fractions, and numbers that are to be treated as strings, you may want
to use this code to load any TSV files related to this repository (provided you're doing it in Python). After a quick
`pip install -U ms3` (requires Python 3.10 or later) you'll be able to load any TSV like this:

```python
import ms3

labels = ms3.load_tsv("harmonies/wa01op05no1a_Allegretto.harmonies.tsv")
notes = ms3.load_tsv("notes/wa01op05no1a_Allegretto.notes.tsv")
```


## Version history

See the [GitHub releases](https://github.com/DCMLab/jc_bach_sonatas/releases).

## Questions, Suggestions, Corrections, Bug Reports

Please [create an issue](https://github.com/DCMLab/jc_bach_sonatas/issues) and/or feel free to fork and submit pull requests.

## Cite as

> Johannes Hentschel, Yannis Rammos, Markus Neuwirth, & Martin Rohrmeier. (2025). Johann Christian Bach – Keyboard Sonatas [Data set]. Zenodo. https://doi.org/{{ concept_doi }}

## License

Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)).